### PR TITLE
Implement minimal AI project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# AI Project
+
+This repository contains a minimal example of an AI powered investment application consisting of an API, web frontend, and background worker.  The code is intentionally lightweight and is designed primarily for demonstration and unit testing purposes.

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -1,0 +1,14 @@
+"""Application configuration using Pydantic settings."""
+
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Simple settings object used by the application."""
+
+    database_url: str = "sqlite:///./test.db"
+    secret_key: str = "change-me"
+    token_algorithm: str = "HS256"
+
+
+settings = Settings()

--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -1,0 +1,13 @@
+"""Minimal security helpers."""
+
+from hashlib import sha256
+
+
+def hash_password(password: str) -> str:
+    """Return a SHA256 hash of the provided password."""
+    return sha256(password.encode("utf-8")).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify a password against a given hash."""
+    return hash_password(password) == hashed

--- a/apps/api/app/db/seed.py
+++ b/apps/api/app/db/seed.py
@@ -1,0 +1,21 @@
+"""Utilities for seeding the database with initial data."""
+
+from app.db.session import SessionLocal, engine
+from app.models import orm
+
+
+def init_db() -> None:
+    """Create tables and insert a few sample recommendations."""
+    orm.Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        if not db.query(orm.Recommendation).first():
+            db.add_all(
+                [
+                    orm.Recommendation(ticker="AAPL", rating="buy"),
+                    orm.Recommendation(ticker="MSFT", rating="hold"),
+                ]
+            )
+            db.commit()
+    finally:
+        db.close()

--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -1,0 +1,21 @@
+"""Database session and engine setup."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+
+engine = create_engine(
+    settings.database_url, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def get_db():
+    """Yield a database session for request handlers."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,0 +1,21 @@
+"""Entry point for the FastAPI application."""
+
+from fastapi import FastAPI
+
+from app.db.seed import init_db
+from app.routes import auth, backtest, news, recs
+from app.ws import stream
+
+app = FastAPI(title="AI Project API")
+
+app.include_router(auth.router)
+app.include_router(backtest.router)
+app.include_router(news.router)
+app.include_router(recs.router)
+app.include_router(stream.router)
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    """Initialize database tables on startup."""
+    init_db()

--- a/apps/api/app/models/orm.py
+++ b/apps/api/app/models/orm.py
@@ -1,0 +1,17 @@
+"""SQLAlchemy ORM models."""
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+class Recommendation(Base):
+    """Simple recommendation model."""
+
+    __tablename__ = "recommendations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticker = Column(String, index=True)
+    rating = Column(String, nullable=False)

--- a/apps/api/app/models/schemas.py
+++ b/apps/api/app/models/schemas.py
@@ -1,0 +1,12 @@
+"""Pydantic models used by the API."""
+
+from pydantic import BaseModel
+
+
+class Recommendation(BaseModel):
+    id: int
+    ticker: str
+    rating: str
+
+    class Config:
+        orm_mode = True

--- a/apps/api/app/routes/auth.py
+++ b/apps/api/app/routes/auth.py
@@ -1,0 +1,14 @@
+"""Authentication routes."""
+
+from fastapi import APIRouter
+
+from app.core import security
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login")
+def login(username: str, password: str):
+    """Return a fake access token for demonstration purposes."""
+    token = security.hash_password(password)
+    return {"access_token": token, "token_type": "bearer"}

--- a/apps/api/app/routes/backtest.py
+++ b/apps/api/app/routes/backtest.py
@@ -1,0 +1,11 @@
+"""Backtest endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/backtest", tags=["backtest"])
+
+
+@router.get("/")
+def run_backtest():
+    """Return a placeholder backtest result."""
+    return {"result": "success"}

--- a/apps/api/app/routes/news.py
+++ b/apps/api/app/routes/news.py
@@ -1,0 +1,11 @@
+"""News endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/news", tags=["news"])
+
+
+@router.get("/")
+def latest_news():
+    """Return a list of sample news articles."""
+    return [{"headline": "Market opens higher"}]

--- a/apps/api/app/routes/recs.py
+++ b/apps/api/app/routes/recs.py
@@ -1,0 +1,15 @@
+"""Routes related to investment recommendations."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models import orm, schemas
+
+router = APIRouter(prefix="/recs", tags=["recs"])
+
+
+@router.get("/", response_model=list[schemas.Recommendation])
+def list_recommendations(db: Session = Depends(get_db)):
+    """Return all recommendations from the database."""
+    return db.query(orm.Recommendation).all()

--- a/apps/api/app/services/alerts_service.py
+++ b/apps/api/app/services/alerts_service.py
@@ -1,0 +1,8 @@
+"""Service for handling alert logic."""
+
+from typing import List
+
+
+def get_alerts() -> List[str]:
+    """Return a list of placeholder alerts."""
+    return ["AAPL crossed 50 DMA"]

--- a/apps/api/app/services/data_service.py
+++ b/apps/api/app/services/data_service.py
@@ -1,0 +1,6 @@
+"""Service for retrieving market data."""
+
+
+def get_price(ticker: str) -> float:
+    """Return a fake price for the given ticker."""
+    return 100.0

--- a/apps/api/app/services/ml_service.py
+++ b/apps/api/app/services/ml_service.py
@@ -1,0 +1,6 @@
+"""Machine learning helper functions."""
+
+
+def predict(ticker: str) -> str:
+    """Return a dummy model prediction for a ticker."""
+    return "buy"

--- a/apps/api/app/services/policy_service.py
+++ b/apps/api/app/services/policy_service.py
@@ -1,0 +1,6 @@
+"""Portfolio policy helper functions."""
+
+
+def generate_policy(risk_level: str) -> str:
+    """Return a placeholder policy description for a risk level."""
+    return f"{risk_level} policy"

--- a/apps/api/app/ws/stream.py
+++ b/apps/api/app/ws/stream.py
@@ -1,0 +1,13 @@
+"""WebSocket endpoint for streaming messages."""
+
+from fastapi import APIRouter, WebSocket
+
+router = APIRouter()
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    """Accept a connection and send a single greeting."""
+    await ws.accept()
+    await ws.send_text("hello")
+    await ws.close()

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "ai-api"
+version = "0.1.0"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "sqlalchemy",
+    "pydantic"
+]

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic

--- a/apps/api/tests/test_recs.py
+++ b/apps/api/tests/test_recs.py
@@ -1,0 +1,16 @@
+"""Tests for the recommendations endpoint."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_list_recommendations():
+    """The API should return the seeded recommendations."""
+    response = client.get("/recs/")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list) and data
+    assert data[0]["ticker"] == "AAPL"

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <section>{children}</section>;
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <div>Dashboard</div>;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>AI Project</div>;
+}

--- a/apps/web/app/symbol/[ticker]/page.tsx
+++ b/apps/web/app/symbol/[ticker]/page.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  params: { ticker: string };
+}
+
+export default function SymbolPage({ params }: Props) {
+  return <div>Symbol: {params.ticker}</div>;
+}

--- a/apps/web/components/Chart.tsx
+++ b/apps/web/components/Chart.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Chart() {
+  return <div>Chart placeholder</div>;
+}

--- a/apps/web/components/RecommendationCard.tsx
+++ b/apps/web/components/RecommendationCard.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface Props {
+  ticker: string;
+  rating: string;
+}
+
+export default function RecommendationCard({ ticker, rating }: Props) {
+  return (
+    <div>
+      {ticker}: {rating}
+    </div>
+  );
+}

--- a/apps/web/components/RiskProfileForm.tsx
+++ b/apps/web/components/RiskProfileForm.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function RiskProfileForm() {
+  return <form>Risk form</form>;
+}

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Toast({ message }: { message: string }) {
+  return <div>{message}</div>;
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,4 @@
+export async function fetchJSON(url: string) {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -1,0 +1,3 @@
+export function formatCurrency(v: number): string {
+  return `$${v.toFixed(2)}`;
+}

--- a/apps/web/lib/ws.ts
+++ b/apps/web/lib/ws.ts
@@ -1,0 +1,3 @@
+export function connect(path: string): WebSocket {
+  return new WebSocket(path);
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function middleware() {
+  return NextResponse.next();
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "worker.py"]

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/apps/worker/tasks/backtest_job.py
+++ b/apps/worker/tasks/backtest_job.py
@@ -1,0 +1,6 @@
+"""Dummy backtesting task."""
+
+
+def backtest() -> dict:
+    """Return a fake backtest result."""
+    return {"status": "ok"}

--- a/apps/worker/tasks/fetch_data.py
+++ b/apps/worker/tasks/fetch_data.py
@@ -1,0 +1,9 @@
+"""Dummy task that pretends to fetch market data."""
+
+import requests
+
+
+def fetch(symbol: str) -> dict:
+    """Return placeholder data for a symbol."""
+    _ = requests.Session()
+    return {"symbol": symbol}

--- a/apps/worker/tasks/train.py
+++ b/apps/worker/tasks/train.py
@@ -1,0 +1,6 @@
+"""Dummy training task."""
+
+
+def train() -> str:
+    """Return a message indicating training completed."""
+    return "model-trained"

--- a/apps/worker/worker.py
+++ b/apps/worker/worker.py
@@ -1,0 +1,14 @@
+"""Entry point for executing worker tasks."""
+
+from tasks import backtest_job, fetch_data, train
+
+
+def main() -> None:
+    """Run a few sample tasks."""
+    print(fetch_data.fetch("AAPL"))
+    print(train.train())
+    print(backtest_job.backtest())
+
+
+if __name__ == "__main__":
+    main()

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS recommendations (
+    id INTEGER PRIMARY KEY,
+    ticker TEXT,
+    rating TEXT
+);

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,3 @@
+# API
+
+The API is built with [FastAPI](https://fastapi.tiangolo.com/). It exposes a small set of endpoints for authentication, backtesting, news retrieval and investment recommendations.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+
+The project is organised as a monorepo with separate applications for the API, web frontend and background worker.  Shared machine learning utilities live in the `ml` package.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,0 +1,3 @@
+# Models
+
+Machine learning models in this repository are intentionally simple and serve only as examples.  A basic function returning a static recommendation is provided.

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,0 +1,3 @@
+# Operations
+
+Dockerfiles and Kubernetes manifests are included under the `infra/` directory to illustrate deployment of each service.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: infra/docker/api.Dockerfile
+    ports:
+      - "8000:8000"
+  web:
+    build:
+      context: ..
+      dockerfile: infra/docker/web.Dockerfile
+    ports:
+      - "3000:3000"
+  worker:
+    build:
+      context: ..
+      dockerfile: infra/docker/worker.Dockerfile

--- a/infra/docker/api.Dockerfile
+++ b/infra/docker/api.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../apps/api/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY ../../apps/api/app /app
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/docker/web.Dockerfile
+++ b/infra/docker/web.Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY ../../apps/web/package.json ./
+RUN npm install
+COPY ../../apps/web /app
+CMD ["npm", "run", "dev"]

--- a/infra/docker/worker.Dockerfile
+++ b/infra/docker/worker.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../apps/worker/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY ../../apps/worker /app
+CMD ["python", "worker.py"]

--- a/infra/k8s/api-deployment.yaml
+++ b/infra/k8s/api-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: api:latest
+          ports:
+            - containerPort: 8000

--- a/infra/k8s/ingress.yaml
+++ b/infra/k8s/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ai-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 3000

--- a/infra/k8s/web-deployment.yaml
+++ b/infra/k8s/web-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: web:latest
+          ports:
+            - containerPort: 3000

--- a/infra/k8s/worker-deployment.yaml
+++ b/infra/k8s/worker-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+        - name: worker
+          image: worker:latest

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,9 @@
+events {}
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://web:3000;
+        }
+    }
+}

--- a/ml/features.py
+++ b/ml/features.py
@@ -1,0 +1,10 @@
+"""Feature engineering helpers."""
+
+from typing import List
+
+
+def compute_moving_average(prices: List[float]) -> float:
+    """Return the mean of the price list."""
+    if not prices:
+        raise ValueError("prices list must not be empty")
+    return sum(prices) / len(prices)

--- a/ml/model.py
+++ b/ml/model.py
@@ -1,0 +1,6 @@
+"""Very small placeholder predictive model."""
+
+
+def predict(feature: float) -> str:
+    """Return a naive prediction based on feature sign."""
+    return "buy" if feature >= 0 else "sell"

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -1,0 +1,6 @@
+"""Simple policy utilities."""
+
+
+def apply_policy(prediction: str, risk: str) -> str:
+    """Combine a model prediction with a risk profile."""
+    return f"{prediction}-{risk}"

--- a/ml/train_pipeline.py
+++ b/ml/train_pipeline.py
@@ -1,0 +1,10 @@
+"""Toy training pipeline."""
+
+from .features import compute_moving_average
+from .model import predict
+
+
+def train_model(data: list[float]) -> str:
+    """Train the model on data and return a prediction."""
+    feature = compute_moving_average(data)
+    return predict(feature)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-project",
+  "private": true,
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "start": "echo 'workspace root'"
+  }
+}

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,1 @@
+Write-Host "Starting dev environment"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Starting dev environment"

--- a/scripts/load_mock_data.py
+++ b/scripts/load_mock_data.py
@@ -1,0 +1,7 @@
+"""Script to initialise the local database with mock data."""
+
+from apps.api.app.db.seed import init_db
+
+
+if __name__ == "__main__":
+    init_db()

--- a/scripts/sync_env.py
+++ b/scripts/sync_env.py
@@ -1,0 +1,12 @@
+"""Utility to display selected environment variables."""
+
+import os
+
+
+def dump_env() -> None:
+    for key in ["DATABASE_URL", "API_URL"]:
+        print(f"{key}={os.getenv(key, '')}")
+
+
+if __name__ == "__main__":
+    dump_env()

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {}
+}


### PR DESCRIPTION
## Summary
- add simple FastAPI API with recommendation endpoint and seed data
- scaffold Next.js web frontend and Python worker with placeholder logic
- document project structure and provide infrastructure templates

## Testing
- `python -m pytest -q` (fails: ModuleNotFoundError: No module named 'fastapi')
- `pip install -r apps/api/requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi)


------
https://chatgpt.com/codex/tasks/task_e_68a0d1861d68832cbb6211add23c148e