### PR TITLE
feat: add basic i18n support with language toggle

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "next": "13.5.0",
@@ -17,6 +18,9 @@
     "typescript": "^5.0.0",
     "tailwindcss": "^3.3.0",
     "autoprefixer": "^10.4.0",
-    "postcss": "^8.4.0"
+    "postcss": "^8.4.0",
+    "vitest": "^0.34.1",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,10 +1,17 @@
-import './styles/globals.css';
+import '../styles/globals.css';
 import React from 'react';
+import { LanguageProvider } from '../lib/i18n/LanguageProvider';
+import Navbar from '../components/Navbar';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <LanguageProvider>
+          <Navbar />
+          {children}
+        </LanguageProvider>
+      </body>
     </html>
   );
 }

--- a/apps/frontend/src/components/KpiCard.tsx
+++ b/apps/frontend/src/components/KpiCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+}
+
+export default function KpiCard({ label, value }: KpiCardProps) {
+  return (
+    <div className="p-4 border rounded">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="text-2xl font-bold">{value}</div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/LanguageToggle.tsx
+++ b/apps/frontend/src/components/LanguageToggle.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useLanguage } from '../lib/i18n/LanguageProvider';
+
+export default function LanguageToggle() {
+  const { locale, toggle } = useLanguage();
+  return (
+    <button onClick={toggle} aria-label="toggle language">
+      {locale === 'en' ? 'AR' : 'EN'}
+    </button>
+  );
+}

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -1,3 +1,14 @@
+'use client';
+
+import LanguageToggle from './LanguageToggle';
+import { useLanguage } from '../lib/i18n/LanguageProvider';
+
 export default function Navbar() {
-  return <nav>Navbar</nav>;
+  const { dict } = useLanguage();
+  return (
+    <nav>
+      <span>{dict.greeting}</span>
+      <LanguageToggle />
+    </nav>
+  );
 }

--- a/apps/frontend/src/components/__tests__/KpiCard.test.tsx
+++ b/apps/frontend/src/components/__tests__/KpiCard.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import KpiCard from '../KpiCard';
+
+describe('KpiCard', () => {
+  it('renders label and value', () => {
+    render(<KpiCard label="Revenue" value="100" />);
+    expect(screen.getByText('Revenue')).toBeTruthy();
+    expect(screen.getByText('100')).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/lib/i18n/LanguageProvider.tsx
+++ b/apps/frontend/src/lib/i18n/LanguageProvider.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import en from './en';
+import ar from './ar';
+
+export type Locale = 'en' | 'ar';
+
+type Dictionary = typeof en;
+
+interface LanguageContextValue {
+  locale: Locale;
+  dict: Dictionary;
+  toggle: () => void;
+}
+
+const dictionaries: Record<Locale, Dictionary> = { en, ar };
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocale] = useState<Locale>('en');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('locale') as Locale | null;
+    if (stored && stored in dictionaries) {
+      setLocale(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    document.documentElement.dir = locale === 'ar' ? 'rtl' : 'ltr';
+    localStorage.setItem('locale', locale);
+  }, [locale]);
+
+  const toggle = () => setLocale((l) => (l === 'en' ? 'ar' : 'en'));
+
+  return (
+    <LanguageContext.Provider value={{ locale, dict: dictionaries[locale], toggle }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider');
+  return ctx;
+}

--- a/apps/frontend/src/lib/i18n/ar.ts
+++ b/apps/frontend/src/lib/i18n/ar.ts
@@ -1,0 +1,3 @@
+export default {
+  greeting: '\u0645\u0631\u062d\u0628\u0627',
+};

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -1,0 +1,3 @@
+export default {
+  greeting: 'Hello',
+};

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add simple English/Arabic dictionaries and LanguageProvider with RTL support
- add LanguageToggle and integrate into Navbar
- scaffold KpiCard component with unit test and Vitest config

## Testing
- `npm test -w apps/frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19e220d90832cb00924eec5a07728