### PR TITLE
Fix API tests by ensuring DB setup and package accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 *.pyd
 dist/
 build/
+*.db

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -1,9 +1,9 @@
-"""Application configuration using Pydantic settings."""
+"""Application configuration for the API."""
 
-from pydantic import BaseSettings
+from pydantic import BaseModel
 
 
-class Settings(BaseSettings):
+class Settings(BaseModel):
     """Simple settings object used by the application."""
 
     database_url: str = "sqlite:///./test.db"

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/apps/api/tests/test_recs.py
+++ b/apps/api/tests/test_recs.py
@@ -4,13 +4,12 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-client = TestClient(app)
-
 
 def test_list_recommendations():
     """The API should return the seeded recommendations."""
-    response = client.get("/recs/")
-    assert response.status_code == 200
-    data = response.json()
-    assert isinstance(data, list) and data
-    assert data[0]["ticker"] == "AAPL"
+    with TestClient(app) as client:
+        response = client.get("/recs/")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list) and data
+        assert data[0]["ticker"] == "AAPL"


### PR DESCRIPTION
## Summary
- Use plain `BaseModel` for API settings and ignore test SQLite DBs
- Ensure test client triggers startup for seeded recommendations
- Add package initializer and adjust test path for imports

## Testing
- `cd apps/api && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1a68b6cb4832cbd8baa96b34fba3d